### PR TITLE
Steam module fix

### DIFF
--- a/modules/nixos/applications/steam.nix
+++ b/modules/nixos/applications/steam.nix
@@ -7,11 +7,11 @@ let
     mkIf
     ;
 
-  cfg = config.kalyx.NAME;
+  cfg = config.kalyx.steam;
 in
 {
-  options.kalyx.NAME = {
-    enable = mkEnableOption "DESCRIPTION";
+  options.kalyx.steam = {
+    enable = mkEnableOption "Steam";
   };
 
   config = mkIf cfg.enable {
@@ -19,13 +19,15 @@ in
     kalyx = { };
     #================#
     
+    # Enable Steam hardware (Steam Controller, HTC Vive, etc...)
+    hardware.steam-hardware.enable = true;
+
     programs.steam = {
       enable = true;
       package = pkgs.steam-small.override {
         extraEnv = {
           MANGOHUD = true;
           OBS_VKCAPTURE = true;
-          RADV_TEX_ANISO = 16;
         };
         extraLibraries = p: with p; [
           atk
@@ -43,7 +45,7 @@ in
           "minsize 1 1, title:^()$,class:^(steam)$"
         ];
       };
-      
+
     }];
   };
 }


### PR DESCRIPTION
steam.nix lacked option names, description, and steam hardware support. Also fixed a bug caused by forcing anisotropic filtering.