### PR TITLE
Improved neofetch.

### DIFF
--- a/modules/home/applications/neofetch.nix
+++ b/modules/home/applications/neofetch.nix
@@ -13,19 +13,47 @@ in
   options.kalyx.neofetch = {
     enable = mkEnableOption "Neofetch";
 
-    imageSource = mkOption {
-      type = types.nullOr types.path;
-      default = null;
+    image= {
+      kalyxSvg = mkEnableOption "Display the Kalyx svg";
+
+      # Must be set for non-ascii images
+      renderer = mkOption {
+        description = "Set the program used to render the image.";
+        type = types.str;
+        default = "ascii";
+        example = "kitty"; # TODO: Document available options (check neofetch source)
+      };
+
+      source = mkOption {
+        description = ''
+          Path to image for neofetch to display.
+          Non-ascii images require setting a renderer.
+        '';
+        type = types.nullOr types.path;
+        default = null;
+        example = ./kalyx-ansii;
+      };
+
+      size = mkOption {
+        description = "Change the size of the rendered image.";
+        type = types.str;
+        default = "auto";
+        example = "320px";
+      };
     };
 
     distroName = mkOption {
+      description = "Text to be shown in the 'OS:' section.";
       type = types.nullOr types.str;
       default = null;
+      example = "Kalyx [Nixos]";
     };
 
     asciiColors = mkOption {
+      description = "Color scheme to use for ascii art.";
       type = types.nullOr types.str;
       default = null;
+      example = "11 3 10 2";
     };
   };
 
@@ -39,7 +67,7 @@ in
         info title
         info underline
         
-        ${if (cfg.distroName != null) then (''distro="${cfg.distroName} x86_64"'') else ""}
+        ${if (cfg.distroName != null) then (''distro="${cfg.distroName}"'') else ""}
         info "OS" distro
         info "Host" model
         info "Kernel" kernel
@@ -72,8 +100,12 @@ in
         info cols
       }
 
+      image_backend=${cfg.image.renderer}
+      image_size=${cfg.image.size}
+
       ${if (cfg.asciiColors != null) then ("ascii_colors=(${cfg.asciiColors})") else ""}
-      ${if (cfg.imageSource != null) then ("image_source=${cfg.imageSource}") else ""}
+      ${if (cfg.image.kalySvg) then ("image_source=${../../../res/kalyx.svg}") else
+        if (cfg.image.source != null) then ("image_source=${cfg.image.source}") else ""}
     '';
   };
 }

--- a/modules/nixos/theming/kalyx/kalyx.nix
+++ b/modules/nixos/theming/kalyx/kalyx.nix
@@ -8,10 +8,11 @@ let
     ;
 
   cfg = config.kalyx.branding;
+  kalyxSvg = config.kalyx.neofetch.image.kalyxSvg;
 in
 {
   options.kalyx.branding = {
-    enable = mkEnableOption "DESCRIPTION";
+    enable = mkEnableOption "Enable Kalyx branding";
   };
 
   config = mkIf cfg.enable {
@@ -25,9 +26,14 @@ in
       kalyx = {
         neofetch = {
           enable = lib.mkDefault true;
-          imageSource = lib.mkDefault ./kalyx-ansii;
-          distroName = lib.mkDefault "Kalyx";
+          # Set distro name based on nixpkgs version and system architecture.
+          # (i.e. "Kalyx [Nixos 24.05] x86_64-linux")
+          distroName = lib.mkDefault "Kalyx [Nixos ${config.system.nixos.release}] ${config.nixpkgs.hostPlatform.system}";
           asciiColors = lib.mkDefault "11 3 10 2";
+          image = {
+            source = lib.mkDefault ./kalyx-ansii;
+            size = mkIf kalyxSvg lib.mkDefault "320px";
+          };
         };
       };
     }];


### PR DESCRIPTION
Added options to choose image size and renderer. This allows for non-ascii images. Added documentation to all the neofetch options.
Added dynamic nixpkg version number and architecture to the default distro name. Fixed the branding module not having a description.