### PR TITLE
Fixed Steam causing hyprland to crash.

### DIFF
--- a/modules/nixos/applications/steam.nix
+++ b/modules/nixos/applications/steam.nix
@@ -34,17 +34,5 @@ in
         ];
       };
     };
-
-    # Home Manager fixes.
-    home-manager.sharedModules = [{
-      
-      # Hyprland steam dropdown menu fix.
-      wayland.windowManager.hyprland.settings = {
-        windowrulev2 = [
-          "stayfocused, title:^()$,class:^(steam)$"
-          "minsize 1 1, title:^()$,class:^(steam)$"
-        ];
-      };
-    }];
   };
 }


### PR DESCRIPTION
Removed the hyprland menu patch as it was causing hyprland to crash, and is no longer needed in 24.05.
See Issue #6